### PR TITLE
feature: use gzip to compress the response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.28.7
 	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.21.1
 	github.com/gin-contrib/cors v1.7.2
+	github.com/gin-contrib/gzip v1.0.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/samber/lo v1.47.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uq
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/cors v1.7.2 h1:oLDHxdg8W/XDoN/8zamqk/Drgt4oVZDvaV0YmvVICQw=
 github.com/gin-contrib/cors v1.7.2/go.mod h1:SUJVARKgQ40dmrzgXEVxj2m7Ig1v1qIboQkPDTQ9t2E=
+github.com/gin-contrib/gzip v1.0.1 h1:HQ8ENHODeLY7a4g1Au/46Z92bdGFl74OhxcZble9WJE=
+github.com/gin-contrib/gzip v1.0.1/go.mod h1:njt428fdUNRvjuJf16tZMYZ2Yl+WQB53X5wmhDwXvC4=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=

--- a/pkg/apiserver/router/router.go
+++ b/pkg/apiserver/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"github.com/gin-contrib/cors"
+	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 
 	"github.com/cloudpilot-ai/priceserver/pkg/apis"
@@ -17,6 +18,8 @@ func NewPriceServerRouter(awsPriceClient *client.AWSPriceClient, alibabaCloudCli
 	config.AllowHeaders = []string{"*"}
 	corsHandler := cors.New(config)
 	router.Use(corsHandler)
+
+	router.Use(gzip.Gzip(gzip.DefaultCompression))
 
 	router.Use(func(context *gin.Context) {
 		context.Set(apis.AWSPriceClientContextKey, awsPriceClient)

--- a/pkg/tools/queryclient.go
+++ b/pkg/tools/queryclient.go
@@ -95,6 +95,8 @@ func (q *QueryClientImpl) refreshSpecificInstanceTypeData(region, instanceType s
 		klog.Errorf("Failed to create request: %v", err)
 		return nil
 	}
+	req.Header.Add("Accept", "Accept-Encoding: gzip")
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		klog.Errorf("Failed to get price data: %v", err)
@@ -135,6 +137,9 @@ func (q *QueryClientImpl) Sync() error {
 		klog.Errorf("Failed to create request: %v", err)
 		return err
 	}
+	// Use gzip to compress the response
+	req.Header.Add("Accept", "Accept-Encoding: gzip")
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		klog.Errorf("Failed to get price data: %v", err)

--- a/vendor/github.com/gin-contrib/gzip/.gitignore
+++ b/vendor/github.com/gin-contrib/gzip/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/vendor/github.com/gin-contrib/gzip/.golangci.yml
+++ b/vendor/github.com/gin-contrib/gzip/.golangci.yml
@@ -1,0 +1,38 @@
+linters:
+  enable-all: false
+  disable-all: true
+  fast: false
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    - gofumpt
+run:
+  timeout: 3m

--- a/vendor/github.com/gin-contrib/gzip/.goreleaser.yaml
+++ b/vendor/github.com/gin-contrib/gzip/.goreleaser.yaml
@@ -1,0 +1,29 @@
+builds:
+  - # If true, skip the build.
+    # Useful for library projects.
+    # Default is false
+    skip: true
+
+changelog:
+  use: github
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: "Bug fixes"
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: "Enhancements"
+      regexp: "^.*chore[(\\w)]*:+.*$"
+      order: 2
+    - title: "Refactor"
+      regexp: "^.*refactor[(\\w)]*:+.*$"
+      order: 3
+    - title: "Build process updates"
+      regexp: ^.*?(build|ci)(\(.+\))??!?:.+$
+      order: 4
+    - title: "Documentation updates"
+      regexp: ^.*?docs?(\(.+\))??!?:.+$
+      order: 4
+    - title: Others
+      order: 999

--- a/vendor/github.com/gin-contrib/gzip/LICENSE
+++ b/vendor/github.com/gin-contrib/gzip/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Gin-Gonic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/gin-contrib/gzip/README.md
+++ b/vendor/github.com/gin-contrib/gzip/README.md
@@ -1,0 +1,135 @@
+# GZIP gin's middleware
+
+[![Run Tests](https://github.com/gin-contrib/gzip/actions/workflows/go.yml/badge.svg)](https://github.com/gin-contrib/gzip/actions/workflows/go.yml)
+[![codecov](https://codecov.io/gh/gin-contrib/gzip/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-contrib/gzip)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gin-contrib/gzip)](https://goreportcard.com/report/github.com/gin-contrib/gzip)
+[![GoDoc](https://godoc.org/github.com/gin-contrib/gzip?status.svg)](https://godoc.org/github.com/gin-contrib/gzip)
+[![Join the chat at https://gitter.im/gin-gonic/gin](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gin-gonic/gin)
+
+Gin middleware to enable `GZIP` support.
+
+## Usage
+
+Download and install it:
+
+```sh
+go get github.com/gin-contrib/gzip
+```
+
+Import it in your code:
+
+```go
+import "github.com/gin-contrib/gzip"
+```
+
+Canonical example:
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "time"
+
+  "github.com/gin-contrib/gzip"
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+  r := gin.Default()
+  r.Use(gzip.Gzip(gzip.DefaultCompression))
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  if err := r.Run(":8080"); err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
+Customized Excluded Extensions
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "time"
+
+  "github.com/gin-contrib/gzip"
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+  r := gin.Default()
+  r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedExtensions([]string{".pdf", ".mp4"})))
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  if err := r.Run(":8080"); err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
+Customized Excluded Paths
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "time"
+
+  "github.com/gin-contrib/gzip"
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+  r := gin.Default()
+  r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPaths([]string{"/api/"})))
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  if err := r.Run(":8080"); err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
+Customized Excluded Paths
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "time"
+
+  "github.com/gin-contrib/gzip"
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+  r := gin.Default()
+  r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPathsRegexs([]string{".*"})))
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  if err := r.Run(":8080"); err != nil {
+    log.Fatal(err)
+  }
+}
+```

--- a/vendor/github.com/gin-contrib/gzip/gzip.go
+++ b/vendor/github.com/gin-contrib/gzip/gzip.go
@@ -1,0 +1,39 @@
+package gzip
+
+import (
+	"compress/gzip"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	BestCompression    = gzip.BestCompression
+	BestSpeed          = gzip.BestSpeed
+	DefaultCompression = gzip.DefaultCompression
+	NoCompression      = gzip.NoCompression
+)
+
+func Gzip(level int, options ...Option) gin.HandlerFunc {
+	return newGzipHandler(level, options...).Handle
+}
+
+type gzipWriter struct {
+	gin.ResponseWriter
+	writer *gzip.Writer
+}
+
+func (g *gzipWriter) WriteString(s string) (int, error) {
+	g.Header().Del("Content-Length")
+	return g.writer.Write([]byte(s))
+}
+
+func (g *gzipWriter) Write(data []byte) (int, error) {
+	g.Header().Del("Content-Length")
+	return g.writer.Write(data)
+}
+
+// Fix: https://github.com/mholt/caddy/issues/38
+func (g *gzipWriter) WriteHeader(code int) {
+	g.Header().Del("Content-Length")
+	g.ResponseWriter.WriteHeader(code)
+}

--- a/vendor/github.com/gin-contrib/gzip/handler.go
+++ b/vendor/github.com/gin-contrib/gzip/handler.go
@@ -1,0 +1,83 @@
+package gzip
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+type gzipHandler struct {
+	*Options
+	gzPool sync.Pool
+}
+
+func newGzipHandler(level int, options ...Option) *gzipHandler {
+	handler := &gzipHandler{
+		Options: DefaultOptions,
+		gzPool: sync.Pool{
+			New: func() interface{} {
+				gz, err := gzip.NewWriterLevel(ioutil.Discard, level)
+				if err != nil {
+					panic(err)
+				}
+				return gz
+			},
+		},
+	}
+	for _, setter := range options {
+		setter(handler.Options)
+	}
+	return handler
+}
+
+func (g *gzipHandler) Handle(c *gin.Context) {
+	if fn := g.DecompressFn; fn != nil && c.Request.Header.Get("Content-Encoding") == "gzip" {
+		fn(c)
+	}
+
+	if !g.shouldCompress(c.Request) {
+		return
+	}
+
+	gz := g.gzPool.Get().(*gzip.Writer)
+	defer g.gzPool.Put(gz)
+	defer gz.Reset(ioutil.Discard)
+	gz.Reset(c.Writer)
+
+	c.Header("Content-Encoding", "gzip")
+	c.Header("Vary", "Accept-Encoding")
+	c.Writer = &gzipWriter{c.Writer, gz}
+	defer func() {
+		gz.Close()
+		c.Header("Content-Length", fmt.Sprint(c.Writer.Size()))
+	}()
+	c.Next()
+}
+
+func (g *gzipHandler) shouldCompress(req *http.Request) bool {
+	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") ||
+		strings.Contains(req.Header.Get("Connection"), "Upgrade") ||
+		strings.Contains(req.Header.Get("Accept"), "text/event-stream") {
+		return false
+	}
+
+	extension := filepath.Ext(req.URL.Path)
+	if g.ExcludedExtensions.Contains(extension) {
+		return false
+	}
+
+	if g.ExcludedPaths.Contains(req.URL.Path) {
+		return false
+	}
+	if g.ExcludedPathesRegexs.Contains(req.URL.Path) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/gin-contrib/gzip/options.go
+++ b/vendor/github.com/gin-contrib/gzip/options.go
@@ -1,0 +1,116 @@
+package gzip
+
+import (
+	"compress/gzip"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	DefaultExcludedExtentions = NewExcludedExtensions([]string{
+		".png", ".gif", ".jpeg", ".jpg",
+	})
+	DefaultOptions = &Options{
+		ExcludedExtensions: DefaultExcludedExtentions,
+	}
+)
+
+type Options struct {
+	ExcludedExtensions   ExcludedExtensions
+	ExcludedPaths        ExcludedPaths
+	ExcludedPathesRegexs ExcludedPathesRegexs
+	DecompressFn         func(c *gin.Context)
+}
+
+type Option func(*Options)
+
+func WithExcludedExtensions(args []string) Option {
+	return func(o *Options) {
+		o.ExcludedExtensions = NewExcludedExtensions(args)
+	}
+}
+
+func WithExcludedPaths(args []string) Option {
+	return func(o *Options) {
+		o.ExcludedPaths = NewExcludedPaths(args)
+	}
+}
+
+func WithExcludedPathsRegexs(args []string) Option {
+	return func(o *Options) {
+		o.ExcludedPathesRegexs = NewExcludedPathesRegexs(args)
+	}
+}
+
+func WithDecompressFn(decompressFn func(c *gin.Context)) Option {
+	return func(o *Options) {
+		o.DecompressFn = decompressFn
+	}
+}
+
+// Using map for better lookup performance
+type ExcludedExtensions map[string]bool
+
+func NewExcludedExtensions(extensions []string) ExcludedExtensions {
+	res := make(ExcludedExtensions)
+	for _, e := range extensions {
+		res[e] = true
+	}
+	return res
+}
+
+func (e ExcludedExtensions) Contains(target string) bool {
+	_, ok := e[target]
+	return ok
+}
+
+type ExcludedPaths []string
+
+func NewExcludedPaths(paths []string) ExcludedPaths {
+	return ExcludedPaths(paths)
+}
+
+func (e ExcludedPaths) Contains(requestURI string) bool {
+	for _, path := range e {
+		if strings.HasPrefix(requestURI, path) {
+			return true
+		}
+	}
+	return false
+}
+
+type ExcludedPathesRegexs []*regexp.Regexp
+
+func NewExcludedPathesRegexs(regexs []string) ExcludedPathesRegexs {
+	result := make([]*regexp.Regexp, len(regexs))
+	for i, reg := range regexs {
+		result[i] = regexp.MustCompile(reg)
+	}
+	return result
+}
+
+func (e ExcludedPathesRegexs) Contains(requestURI string) bool {
+	for _, reg := range e {
+		if reg.MatchString(requestURI) {
+			return true
+		}
+	}
+	return false
+}
+
+func DefaultDecompressHandle(c *gin.Context) {
+	if c.Request.Body == nil {
+		return
+	}
+	r, err := gzip.NewReader(c.Request.Body)
+	if err != nil {
+		_ = c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	c.Request.Header.Del("Content-Encoding")
+	c.Request.Header.Del("Content-Length")
+	c.Request.Body = r
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,6 +258,9 @@ github.com/gabriel-vasile/mimetype/internal/magic
 # github.com/gin-contrib/cors v1.7.2
 ## explicit; go 1.18
 github.com/gin-contrib/cors
+# github.com/gin-contrib/gzip v1.0.1
+## explicit; go 1.18
+github.com/gin-contrib/gzip
 # github.com/gin-contrib/sse v0.1.0
 ## explicit; go 1.12
 github.com/gin-contrib/sse


### PR DESCRIPTION
Fixes #none

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* feature: use gzip to compress the response

After using this, The network data is much smaller：
![image](https://github.com/user-attachments/assets/03de16f5-bcb4-4da2-9c3e-db2e529b6fbb)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```